### PR TITLE
(maint) Bump maximum Bolt version, fix url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+* Bump maximum Bolt version to 4.0, fix metadata url.
+
 ## Release 0.1.0
 
 Initial release

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,15 @@
 {
   "name": "puppetlabs-ruby_plugin_helper",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "A helper for writing Bolt plugins in Ruby",
   "license": "Apache-2.0",
-  "source": "git@github.com/puppetlabs/puppetlabs-bolt_plugin_helper",
+  "source": "https://github.com/puppetlabs/puppetlabs-ruby_plugin_helper",
   "dependencies": [],
   "requirements": [
     {
       "name": "bolt",
-      "version_requirement": "< 3.0"
+      "version_requirement": "< 4.0"
     }
   ],
   "pdk-version": "1.7.0",


### PR DESCRIPTION
This bumps the maximum Bolt version to 4.0, as 3.0 is not expected to
break this module. This also fixes the URL in the metadata.