### PR TITLE
(maint) Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+name: "Publish module"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-github-release:
+    name: Deploy GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+      - name: Get Version
+        id: gv
+        run: |
+          echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
+      - name: Create Release
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.gv.outputs.ver }}
+          draft: false
+          prerelease: false
+
+  deploy-forge:
+    name: Deploy to Forge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+      - name: PDK Build
+        uses: docker://puppet/pdk:nightly
+        with:
+          args: 'build --force'
+      - name: Push to Forge
+        uses: docker://puppet/pdk:nightly
+        with:
+          args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'


### PR DESCRIPTION
This adds a new release workflow that can be used to tag and release a
new version of the module. The tag is retrieved from the module's
current metadata on the `main` branch.