### PR TITLE
Release prep v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.0
+
+* Implement Puppet version requirement
+* Update configuration files to be in line with pdk-templates
+
 ## Release 0.2.0
 
 * Bump maximum Bolt version to 4.0, fix metadata url.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ruby_plugin_helper",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "Puppet, Inc.",
   "summary": "A helper for writing Bolt plugins in Ruby",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release prep for the ruby_task_helper module

Please verify before merging:

- [ ] last [CI](https://github.com/puppetlabs/puppetlabs-terraform/pull/36) run is green
- [ ] [Changelog](https://github.com/puppetlabs/puppetlabs-ruby_task_helper/blob/release-prep/CHANGELOG.md) is readable
- [ ] Ensure the [changelog](https://github.com/puppetlabs/puppetlabs-ruby_task_helper/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/puppetlabs/puppetlabs-ruby_task_helper/blob/release-prep/metadata.json) version match