### PR TITLE
Release prep 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Release 1.0.0
+## Release 0.3.0
 
 * Implement Puppet version requirement
 * Update configuration files to be in line with pdk-templates

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ruby_plugin_helper",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "author": "Puppet, Inc.",
   "summary": "A helper for writing Bolt plugins in Ruby",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release prep for puppetlabs-ruby_plugin_helper for version 0.3.0