### PR TITLE
(BOLT-28) Fix OS support list

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,9 +9,7 @@
 
   ],
   "operatingsystem_support": [
-    "RedHat based Linux",
-    "Debian based Linux",
-    "Windows"
+
   ],
   "requirements": [
     {


### PR DESCRIPTION
Prior to this commit, a PDK update applied the wrong format to the OS support list in the metadata.json file. This commit fixes it by reverting to the previous list, so that it can be released to the Forge.